### PR TITLE
Compare refs both ways round, other small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <a href="https://github.com/Addepar/RedFlag">
-    <img src="docs/images/RedFlag-Logo.png" alt="RedFlag" height="100">
+    <img src="https://raw.githubusercontent.com/Addepar/RedFlag/main/docs/images/RedFlag-Logo.png" alt="RedFlag" height="100">
   </a>
 
 
@@ -281,9 +281,9 @@ Say hi to Addepar Security Engineering at [security-engineering@addepar.com](mai
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://www.linkedin.com/company/addepar
 
-[animated-report]: docs/images/Report-Animated.gif
+[animated-report]: https://raw.githubusercontent.com/Addepar/RedFlag/main/docs/images/Report-Animated.gif
 [animated-report-url]: TBD
-[batch-workflow]: docs/images/Batch-Workflow.png
+[batch-workflow]: https://raw.githubusercontent.com/Addepar/RedFlag/main/docs/images/Batch-Workflow.png
 [docs-ci-mode]: https://img.shields.io/badge/Read%20More-How%20To%20Use%20RedFlag%20In%20CI%20Mode-blue?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAABcUlEQVRoBe1ZQU7DMBBsOPMC3gISDwDxAr5BJe5I/Ki3gkS58ROO9MKFdJZmLyOysWIzUNiVVs527Rl7JrnUi8V/iL7vr5CPyC1SFQ9NtMVu71U7Zp7qAwDQlLd4R94gT6pBCwCM0KJgajwFGPbaWCzjmW27e8o2B3gbwD6Vx/Ozg3/DuHEZHNvraDyKmugdU/+D6pZle2xXAuPBvkJ+BvuIl8hf9xF30Ttgu4/6ot6m67qzMa6pb8DXneNhhXz1H4Tj6Wwuc8BiDGDfHe+PrSv9vQS/1IFSTvm8PIBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQefnnHdiapPibW3IzM8e+KQdeBtDrOeA/vgbKXw6XDF/ekZVcQNQcogQ/vCMzcoDcYbit2UjtWtyRTe4z5MAhLpBrpF9841EWT+HmDr25A8AdiN2uwvv8AAAAAElFTkSuQmCC
 [docs-ci-mode-url]: https://github.com/Addepar/RedFlag/wiki/CI-Mode
 [docs-eval-mode]: https://img.shields.io/badge/Read%20More-How%20To%20Use%20RedFlag%20In%20Evaluation%20Mode-blue?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAABcUlEQVRoBe1ZQU7DMBBsOPMC3gISDwDxAr5BJe5I/Ki3gkS58ROO9MKFdJZmLyOysWIzUNiVVs527Rl7JrnUi8V/iL7vr5CPyC1SFQ9NtMVu71U7Zp7qAwDQlLd4R94gT6pBCwCM0KJgajwFGPbaWCzjmW27e8o2B3gbwD6Vx/Ozg3/DuHEZHNvraDyKmugdU/+D6pZle2xXAuPBvkJ+BvuIl8hf9xF30Ttgu4/6ot6m67qzMa6pb8DXneNhhXz1H4Tj6Wwuc8BiDGDfHe+PrSv9vQS/1IFSTvm8PIBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQeZkOyCUnwnSABJGX6YBcciJMB0gQefnnHdiapPibW3IzM8e+KQdeBtDrOeA/vgbKXw6XDF/ekZVcQNQcogQ/vCMzcoDcYbit2UjtWtyRTe4z5MAhLpBrpF9841EWT+HmDr25A8AdiN2uwvv8AAAAAElFTkSuQmCC

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Say hi to Addepar Security Engineering at [security-engineering@addepar.com](mai
 [issues-shield]: https://img.shields.io/github/issues/Addepar/RedFlag.svg?style=for-the-badge
 [issues-url]: https://github.com/Addepar/RedFlag/issues
 [license-shield]: https://img.shields.io/github/license/Addepar/RedFlag.svg?style=for-the-badge
-[license-url]: https://github.com/Addepar/RedFlag/blob/main/LICENSE.txt
+[license-url]: https://github.com/Addepar/RedFlag/blob/main/LICENSE.md
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 [linkedin-url]: https://www.linkedin.com/company/addepar
 

--- a/addepar_redflag/util/cli.py
+++ b/addepar_redflag/util/cli.py
@@ -16,6 +16,7 @@ from .config import (
 )
 from .console import (
     pretty_print,
+    pretty_print_header,
     pretty_print_traceback,
     MessageType
 )
@@ -36,10 +37,7 @@ def common_arguments(parser, default_config):
 
 
 def cli():
-    pretty_print(
-        'Starting RedFlag 🚩',
-        MessageType.INFO
-    )
+    pretty_print_header()
 
     # Load env var file, if present
     load_dotenv()

--- a/addepar_redflag/util/config.py
+++ b/addepar_redflag/util/config.py
@@ -2,15 +2,15 @@ import yaml
 from os import getenv
 from pathlib import Path
 
-from .llm import (
-    DEFAULT_ROLE,
-    DEFAULT_REVIEW_QUESTION,
-    DEFAULT_TEST_PLAN_QUESTION
-)
 from .console import (
     pretty_print,
     pretty_print_config_table,
     MessageType
+)
+from .llm import (
+    DEFAULT_ROLE,
+    DEFAULT_REVIEW_QUESTION,
+    DEFAULT_TEST_PLAN_QUESTION
 )
 
 def _update_nested_dict(

--- a/addepar_redflag/util/console.py
+++ b/addepar_redflag/util/console.py
@@ -20,10 +20,10 @@ class MessageType(Enum):
 
 # Define the styles with emojis
 styles = {
-    MessageType.SUCCESS: Style(color="green", bold=True),
-    MessageType.WARN: Style(color="yellow", bold=True),
-    MessageType.FATAL: Style(color="red", bold=True, underline=True),
-    MessageType.INFO: Style(color="blue", bold=True)
+    MessageType.SUCCESS: Style(color="green", bold=False),
+    MessageType.WARN: Style(color="yellow", bold=False),
+    MessageType.FATAL: Style(color="red", bold=False, underline=True),
+    MessageType.INFO: Style(color="blue", bold=False)
 }
 
 # Define the emojis
@@ -40,6 +40,14 @@ def str2bool(string: str) -> bool:
         return False
 
     return string.lower() in ('yes', 'true', 't', 'y', '1')
+
+
+# Helper function for standard formatting
+def pretty_print_header():
+    CONSOLE.print(
+        "Starting [bold]RedFlag 🚩[/bold]",
+        style=Style()
+    )
 
 
 # Helper function for standard formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "addepar-redflag"
-version = "0.1.0"
+version = "0.2.0"
 description = "RedFlag uses AI to identify high-risk code changes. Run it in batch mode for release candidate testing or in CI pipelines to flag PRs and add reviewers. RedFlag's flexible configuration makes it valuable for any team."
 authors = ["Addepar Security Engineering <security-engineering@addepar.com>"]
 repository = "https://github.com/Addepar/RedFlag"


### PR DESCRIPTION
Allows users to specify `from` or `to` either way round; if nothing is found one way, try the other.  Some other small updates also, e.g., README with absolute image refs for PyPI.