### PR TITLE
Update URL to use GitHub Pages for gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ redflag --config custom-config.yml
 
 By default, RedFlag produces an HTML report that can be opened in a browser.
 <a href="https://opensource.addepar.com/RedFlag/">
-   <img src="https://raw.githubusercontent.com/Addepar/RedFlag/main/docs/images/Report-Animated.gif">
+   <img src="https://opensource.addepar.com/RedFlag/images/Report-Animated.gif">
 </a>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "addepar-redflag"
-version = "0.2.1"
+version = "0.2.2"
 description = "RedFlag uses AI to identify high-risk code changes. Run it in batch mode for release candidate testing or in CI pipelines to flag PRs and add reviewers. RedFlag's flexible configuration makes it valuable for any team."
 authors = ["Addepar Security Engineering <security-engineering@addepar.com>"]
 repository = "https://github.com/Addepar/RedFlag"


### PR DESCRIPTION
This fixes PyPi's presentation of the gif as there is an issue with the `Content-Type` header. Instead, we're hosting it on GitHub Pages.