### PR TITLE
fix: asyncio issues from multiple caller repos in ci

### DIFF
--- a/addepar_redflag/util/cli.py
+++ b/addepar_redflag/util/cli.py
@@ -48,6 +48,7 @@ async def run_redflag(github, jira, config):
     await redflag(
         github=github,
         jira=Jira,
+        slack=Slack,
         config=config
     )
 
@@ -86,7 +87,7 @@ def cli():
 
     # Validate Bedrock configuration
     final_config['bedrock']['profile'] = validate_aws_credentials(final_config['bedrock']['profile'])
-    
+
     # Instantiate GitHub object
     github_token = final_config['github_token']
     auth = Auth.Token(github_token) if github_token else None
@@ -107,7 +108,7 @@ def cli():
                 MessageType.FATAL
             )
             exit(1)
-            
+
         jira = Jira(
             url=final_config['jira']['url'],
             username=jira_user,

--- a/addepar_redflag/util/cli.py
+++ b/addepar_redflag/util/cli.py
@@ -35,6 +35,20 @@ def common_arguments(parser, default_config):
     parser.add_argument('--no-progress-bar', action='store_false', dest='progress_bar', help='Flag to not display a progress bar.')
     parser.add_argument('--no-strip-html-comments', action='store_false', dest='strip_html_comments', help='Flag to not strip HTML comments from PR descriptions.')
 
+async def run_evaluations(github, jira, dataset, config):
+    await do_evaluations(
+        github=github,
+        jira=Jira,
+        dataset=dataset,
+        config=config
+    )
+
+async def run_redflag(github, jira, config):
+    await redflag(
+        github=github,
+        jira=Jira,
+        config=config
+    )
 
 def cli():
     pretty_print_header()
@@ -104,24 +118,21 @@ def cli():
     try:
         if args.command == 'eval':
             dataset = Path(final_config['dataset'])
-            asyncio.run(do_evaluations(
+            asyncio.run(run_evaluations(
                 github=github,
                 jira=jira,
                 dataset=dataset,
                 config=final_config
             ))
         else:
-            asyncio.run(redflag(
+            asyncio.run(run_redflag(
                 github=github,
                 jira=jira,
                 config=final_config
             ))
-
-    # Unhandled exception handler
     except Exception as e:
         pretty_print(
-            f'An unhandled exception occurred: {e}',
+            f'Failed to evaluate against {llm.model}, exception: {e}',
             MessageType.FATAL
         )
-        pretty_print_traceback()
         exit(1)


### PR DESCRIPTION
found a bug when running CI mode from multiple caller repos, example error indicates that the await keyword is being used outside of an async function:

```shell
│   187 │   │   │   "asyncio.run() cannot be called from a running event loop" │
│   188 │                                                                      │
│   189 │   with Runner(debug=debug) as runner:                                │
│ ❱ 190 │   │   return runner.run(main)     
```

- run_evaluations and run_redflag are defined as async functions.
- The cli function uses asyncio.run to run these async functions, ensuring that await is used correctly within an async context.
- The eval command is properly handled by the evaluate_parser subparser.

note: `slack=Slack`, would need including on successful merge of https://github.com/Addepar/RedFlag/pull/12